### PR TITLE
Add pyyaml to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pure-python-adb
 pygdbmi>=0.9.0.3
 colorama
+pyyaml


### PR DESCRIPTION
`import yaml` at L10:
https://github.com/quarkslab/AERoot/blob/3a19e02d16c5aa126569bb47cc542fbcddc4f9bd/aeroot.py#L10
but `pyyaml` is missing in requirements.

It leads to the following error:
```
Traceback (most recent call last):
  File "/Users/francois/code/AERoot/aeroot.py", line 10, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```