### PR TITLE
Add --rm to Docker commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ A Docker image of *AERoot* is available on [dockerhub](https://hub.docker.com/r/
 #### Usage
 
 ```bash
-docker run --network host ha0ris/aeroot [aeroot options]
+docker run --rm --network host ha0ris/aeroot [aeroot options]
 ```
 
 #### Example
 
 ```bash
-docker run --network host ha0ris/aeroot daemon
+docker run --rm --network host ha0ris/aeroot daemon
 ```
 
 ### macOS
@@ -78,13 +78,13 @@ docker run --network host ha0ris/aeroot daemon
 #### Usage
 
 ```bash
-docker run ha0ris/aeroot --host host.docker.internal [aeroot options]
+docker run --rm ha0ris/aeroot --host host.docker.internal [aeroot options]
 ```
 
 #### Example
 
 ```bash
-docker run ha0ris/aeroot --host host.docker.internal daemon
+docker run --rm ha0ris/aeroot --host host.docker.internal daemon
 ```
 
 # Quick-start


### PR DESCRIPTION
Proposal to add `--rm` to Docker commands in order to remove the container after being EXITED (0).
Avoids lingering containers after each `docker run` execution.